### PR TITLE
Refresh token adopted to direct LIA calls

### DIFF
--- a/LithiumExample.xcodeproj/project.pbxproj
+++ b/LithiumExample.xcodeproj/project.pbxproj
@@ -132,7 +132,7 @@
 		2A27AA0520C1470D00AD2F77 /* Alamofire.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2A0C35E920C13BEC00A98328 /* Alamofire.framework */; };
 		2A27AA0820C14C9400AD2F77 /* LiUIComponents.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2A27A96E20C1466300AD2F77 /* LiUIComponents.framework */; };
 		2A27AA0B20C5260E00AD2F77 /* Alamofire.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2A0C35E920C13BEC00A98328 /* Alamofire.framework */; };
-		2A86142720DCF79E0040781E /* LiAuthResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A86142620DCF79E0040781E /* LiAuthResponse.swift */; };
+		2A86142720DCF79E0040781E /* AuthResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A86142620DCF79E0040781E /* AuthResponse.swift */; };
 		2ADFE61220BEA48F006B3F83 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2ADFE61120BEA48F006B3F83 /* AppDelegate.swift */; };
 		2ADFE61420BEA48F006B3F83 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2ADFE61320BEA48F006B3F83 /* ViewController.swift */; };
 		2ADFE61720BEA48F006B3F83 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 2ADFE61520BEA48F006B3F83 /* Main.storyboard */; };
@@ -328,7 +328,7 @@
 		2A27A9CE20C146A300AD2F77 /* LiBoardViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LiBoardViewController.swift; sourceTree = "<group>"; };
 		2A27A9CF20C146A300AD2F77 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Images.xcassets; sourceTree = "<group>"; };
 		2A27AA0920C5258900AD2F77 /* Alamofire.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Alamofire.framework; path = ../Carthage/Build/iOS/Alamofire.framework; sourceTree = "<group>"; };
-		2A86142620DCF79E0040781E /* LiAuthResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiAuthResponse.swift; sourceTree = "<group>"; };
+		2A86142620DCF79E0040781E /* AuthResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthResponse.swift; sourceTree = "<group>"; };
 		2ADFE60E20BEA48F006B3F83 /* LithiumExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = LithiumExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		2ADFE61120BEA48F006B3F83 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		2ADFE61320BEA48F006B3F83 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
@@ -432,7 +432,7 @@
 				2A0C357320C13A0900A98328 /* LiAuthState.swift */,
 				2A0C357420C13A0900A98328 /* LiLoginViewController.swift */,
 				2A0C357520C13A0900A98328 /* LiSSOAuthResponse.swift */,
-				2A86142620DCF79E0040781E /* LiAuthResponse.swift */,
+				2A86142620DCF79E0040781E /* AuthResponse.swift */,
 			);
 			path = Auth;
 			sourceTree = "<group>";
@@ -1084,7 +1084,7 @@
 				2A0C35C820C13A0A00A98328 /* LiUser.swift in Sources */,
 				2A0C35BD20C13A0A00A98328 /* LiGenericQueryResponse.swift in Sources */,
 				2A0C35D320C13A0A00A98328 /* LiImageUpload.swift in Sources */,
-				2A86142720DCF79E0040781E /* LiAuthResponse.swift in Sources */,
+				2A86142720DCF79E0040781E /* AuthResponse.swift in Sources */,
 				2A0C35B620C13A0A00A98328 /* LiQuerySetting.swift in Sources */,
 				2A0C35CA20C13A0A00A98328 /* KeychainItemAccessibility.swift in Sources */,
 			);

--- a/LithiumExample.xcodeproj/project.pbxproj
+++ b/LithiumExample.xcodeproj/project.pbxproj
@@ -132,6 +132,8 @@
 		2A27AA0520C1470D00AD2F77 /* Alamofire.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2A0C35E920C13BEC00A98328 /* Alamofire.framework */; };
 		2A27AA0820C14C9400AD2F77 /* LiUIComponents.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2A27A96E20C1466300AD2F77 /* LiUIComponents.framework */; };
 		2A27AA0B20C5260E00AD2F77 /* Alamofire.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2A0C35E920C13BEC00A98328 /* Alamofire.framework */; };
+		2A86142720DCF79E0040781E /* LiAuthResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A86142620DCF79E0040781E /* LiAuthResponse.swift */; };
+		2A86142820DCF79E0040781E /* LiAuthResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A86142620DCF79E0040781E /* LiAuthResponse.swift */; };
 		2ADFE61220BEA48F006B3F83 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2ADFE61120BEA48F006B3F83 /* AppDelegate.swift */; };
 		2ADFE61420BEA48F006B3F83 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2ADFE61320BEA48F006B3F83 /* ViewController.swift */; };
 		2ADFE61720BEA48F006B3F83 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 2ADFE61520BEA48F006B3F83 /* Main.storyboard */; };
@@ -327,6 +329,7 @@
 		2A27A9CE20C146A300AD2F77 /* LiBoardViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LiBoardViewController.swift; sourceTree = "<group>"; };
 		2A27A9CF20C146A300AD2F77 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Images.xcassets; sourceTree = "<group>"; };
 		2A27AA0920C5258900AD2F77 /* Alamofire.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Alamofire.framework; path = ../Carthage/Build/iOS/Alamofire.framework; sourceTree = "<group>"; };
+		2A86142620DCF79E0040781E /* LiAuthResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiAuthResponse.swift; sourceTree = "<group>"; };
 		2ADFE60E20BEA48F006B3F83 /* LithiumExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = LithiumExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		2ADFE61120BEA48F006B3F83 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		2ADFE61320BEA48F006B3F83 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
@@ -430,6 +433,7 @@
 				2A0C357320C13A0900A98328 /* LiAuthState.swift */,
 				2A0C357420C13A0900A98328 /* LiLoginViewController.swift */,
 				2A0C357520C13A0900A98328 /* LiSSOAuthResponse.swift */,
+				2A86142620DCF79E0040781E /* LiAuthResponse.swift */,
 			);
 			path = Auth;
 			sourceTree = "<group>";
@@ -1081,6 +1085,7 @@
 				2A0C35C820C13A0A00A98328 /* LiUser.swift in Sources */,
 				2A0C35BD20C13A0A00A98328 /* LiGenericQueryResponse.swift in Sources */,
 				2A0C35D320C13A0A00A98328 /* LiImageUpload.swift in Sources */,
+				2A86142720DCF79E0040781E /* LiAuthResponse.swift in Sources */,
 				2A0C35B620C13A0A00A98328 /* LiQuerySetting.swift in Sources */,
 				2A0C35CA20C13A0A00A98328 /* KeychainItemAccessibility.swift in Sources */,
 			);
@@ -1092,6 +1097,7 @@
 			files = (
 				2A0C35E220C13A2400A98328 /* LiClientRequestParamsTests.swift in Sources */,
 				2A0C35E420C13A2400A98328 /* LiAppCredentialsTests.swift in Sources */,
+				2A86142820DCF79E0040781E /* LiAuthResponse.swift in Sources */,
 				2A0C35E320C13A2400A98328 /* LiSDKManagerTests.swift in Sources */,
 				2AFC13BE20DA5643004A2E8B /* NotificationProviders.swift in Sources */,
 			);

--- a/LithiumExample.xcodeproj/project.pbxproj
+++ b/LithiumExample.xcodeproj/project.pbxproj
@@ -133,7 +133,6 @@
 		2A27AA0820C14C9400AD2F77 /* LiUIComponents.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2A27A96E20C1466300AD2F77 /* LiUIComponents.framework */; };
 		2A27AA0B20C5260E00AD2F77 /* Alamofire.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2A0C35E920C13BEC00A98328 /* Alamofire.framework */; };
 		2A86142720DCF79E0040781E /* LiAuthResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A86142620DCF79E0040781E /* LiAuthResponse.swift */; };
-		2A86142820DCF79E0040781E /* LiAuthResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A86142620DCF79E0040781E /* LiAuthResponse.swift */; };
 		2ADFE61220BEA48F006B3F83 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2ADFE61120BEA48F006B3F83 /* AppDelegate.swift */; };
 		2ADFE61420BEA48F006B3F83 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2ADFE61320BEA48F006B3F83 /* ViewController.swift */; };
 		2ADFE61720BEA48F006B3F83 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 2ADFE61520BEA48F006B3F83 /* Main.storyboard */; };
@@ -1097,7 +1096,6 @@
 			files = (
 				2A0C35E220C13A2400A98328 /* LiClientRequestParamsTests.swift in Sources */,
 				2A0C35E420C13A2400A98328 /* LiAppCredentialsTests.swift in Sources */,
-				2A86142820DCF79E0040781E /* LiAuthResponse.swift in Sources */,
 				2A0C35E320C13A2400A98328 /* LiSDKManagerTests.swift in Sources */,
 				2AFC13BE20DA5643004A2E8B /* NotificationProviders.swift in Sources */,
 			);

--- a/Sources/LiCore/Auth/AuthResponse.swift
+++ b/Sources/LiCore/Auth/AuthResponse.swift
@@ -14,20 +14,22 @@
 
 import Foundation
 
-struct LiAuthResponse {
+struct AuthResponse {
     func setAuthResponse(data: [String: Any]) -> Error? {
         guard let accessToken = data["access_token"] as? String,
             let refreshToken = data["refresh_token"] as? String,
-            let userID = data["userId"] as? String,
-            let lithiumUserID = data["lithiumUserId"] as? String,
             let expiresIn = data["expires_in"] as? Double else {
                 let error = LiBaseError(errorMessage: LiCoreConstants.ErrorMessages.invalidAccessToken, httpCode: LiCoreConstants.ErrorCodes.forbidden)
                 return error
         }
         LiSDKManager.shared().authState.set(accessToken: accessToken)
         LiSDKManager.shared().authState.set(refreshToken: refreshToken)
-        LiSDKManager.shared().authState.set(userID: userID)
-        LiSDKManager.shared().authState.set(lithiumUserID: lithiumUserID)
+        if let userId =  data["userId"] as? String {
+            LiSDKManager.shared().authState.set(userID: userId)
+        }
+        if let lithiumUserId =  data["lithiumUserId"] as? String {
+            LiSDKManager.shared().authState.set(lithiumUserID: lithiumUserId)
+        }
         let currentDate = NSDate()
         let newDate = NSDate(timeInterval: expiresIn, since: currentDate as Date)
         LiSDKManager.shared().authState.set(expiryDate: newDate)
@@ -40,7 +42,7 @@ struct LiAuthResponse {
         do {
             let json =  try JSONSerialization.jsonObject(with: responseData, options: []) as? [String: Any]
             if let data = json?["data"] as? [String: Any] {
-                let error =  LiAuthResponse().setAuthResponse(data: data)
+                let error =  AuthResponse().setAuthResponse(data: data)
                 return error
             } else {
                 if let jsonData = json {

--- a/Sources/LiCore/Auth/AuthResponse.swift
+++ b/Sources/LiCore/Auth/AuthResponse.swift
@@ -37,7 +37,7 @@ struct AuthResponse {
     }
     func setAuthResponse(data: Data?) -> Error? {
         guard let responseData = data else {
-            return LiBaseError(errorMessage: LiCoreConstants.ErrorMessages.refreshFailed, httpCode: LiCoreConstants.ErrorCodes.unauthorized)
+            return LiBaseError(errorMessage: LiCoreConstants.ErrorMessages.refreshFailed, httpCode: LiCoreConstants.ErrorCodes.forbidden)
         }
         do {
             let json =  try JSONSerialization.jsonObject(with: responseData, options: []) as? [String: Any]
@@ -49,7 +49,7 @@ struct AuthResponse {
                     let error = LiBaseError(data: jsonData)
                     return error
                 } else {
-                    return LiBaseError(errorMessage: LiCoreConstants.ErrorMessages.refreshFailed, httpCode: LiCoreConstants.ErrorCodes.serverError)
+                    return LiBaseError(errorMessage: LiCoreConstants.ErrorMessages.refreshFailed, httpCode: LiCoreConstants.ErrorCodes.forbidden)
                 }
             }
         } catch let error {

--- a/Sources/LiCore/Auth/LiAuthResponse.swift
+++ b/Sources/LiCore/Auth/LiAuthResponse.swift
@@ -1,0 +1,24 @@
+// Copyright 2018 Lithium Technologies
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+
+struct LiAuthResponse {
+    var accessToken: String?
+    var refreshToken: String?
+    var expiresIn: String?
+    var userId: String?
+    var lithiumUserId: String?
+    //TODO:- Move the logic to parse and save tokens here.
+}

--- a/Sources/LiCore/Auth/LiAuthResponse.swift
+++ b/Sources/LiCore/Auth/LiAuthResponse.swift
@@ -21,4 +21,24 @@ struct LiAuthResponse {
     var userId: String?
     var lithiumUserId: String?
     //TODO:- Move the logic to parse and save tokens here.
+    func setAuthResponse(data: [String: Any]) -> Error? {
+        guard let accessToken = data["access_token"] as? String,
+            let refreshToken = data["refresh_token"] as? String,
+            let userID = data["userId"] as? String,
+            let lithiumUserID = data["lithiumUserId"] as? String,
+            let expiresIn = data["expires_in"] as? Double else {
+                let error = LiBaseError(errorMessage: LiCoreConstants.ErrorMessages.invalidAccessToken, httpCode: LiCoreConstants.ErrorCodes.forbidden)
+                //self.loginViewController?.dismiss(animated: true, completion: nil)
+                // self.authDelegate?.login(status: false, userId: nil, error: error)
+                return error
+        }
+        LiSDKManager.shared().authState.set(accessToken: accessToken)
+        LiSDKManager.shared().authState.set(refreshToken: refreshToken)
+        LiSDKManager.shared().authState.set(userID: userID)
+        LiSDKManager.shared().authState.set(lithiumUserID: lithiumUserID)
+        let currentDate = NSDate()
+        let newDate = NSDate(timeInterval: expiresIn, since: currentDate as Date)
+        LiSDKManager.shared().authState.set(expiryDate: newDate)
+        return nil
+    }
 }

--- a/Sources/LiCore/Auth/LiAuthService.swift
+++ b/Sources/LiCore/Auth/LiAuthService.swift
@@ -87,11 +87,10 @@ extension LiAuthService: LiLoginViewControllerProtocol {
     }
     /**
      Gets access token.
-     - parameter authCode: AuthCode obtained from login successfully with either webview or sso token.
+     - parameter authCode: AuthCode obtained by login successfully with either webview or sso token.
      */
     func requestAccessToken(authCode: String) {
         LiRestClient.sharedInstance.request(client: LiClient.getAccessToken(code: authCode), success: { [weak self] (response: LiBaseResponse) in
-            //TODO: Move this logic to LiAuthResponse
             let error = LiAuthResponse().setAuthResponse(data: response.data)
             if error != nil {
                 self?.loginViewController?.dismiss(animated: true, completion: nil)

--- a/Sources/LiCore/Auth/LiAuthService.swift
+++ b/Sources/LiCore/Auth/LiAuthService.swift
@@ -90,32 +90,21 @@ extension LiAuthService: LiLoginViewControllerProtocol {
      - parameter authCode: AuthCode obtained from login successfully with either webview or sso token.
      */
     func requestAccessToken(authCode: String) {
-        LiRestClient.sharedInstance.request(client: LiClient.getAccessToken(code: authCode), success: { (response: LiBaseResponse) in
+        LiRestClient.sharedInstance.request(client: LiClient.getAccessToken(code: authCode), success: { [weak self] (response: LiBaseResponse) in
             //TODO: Move this logic to LiAuthResponse
-            guard let accessToken = response.data["access_token"] as? String,
-                let refreshToken = response.data["refresh_token"] as? String,
-                let userID = response.data["userId"] as? String,
-                let lithiumUserID = response.data["lithiumUserId"] as? String,
-                let expiresIn = response.data["expires_in"] as? Double else {
-                    let error = LiBaseError(errorMessage: LiCoreConstants.ErrorMessages.invalidAccessToken, httpCode: LiCoreConstants.ErrorCodes.forbidden)
-                    self.loginViewController?.dismiss(animated: true, completion: nil)
-                    self.authDelegate?.login(status: false, userId: nil, error: error)
-                    return
+            let error = LiAuthResponse().setAuthResponse(data: response.data)
+            if error != nil {
+                self?.loginViewController?.dismiss(animated: true, completion: nil)
+                self?.authDelegate?.login(status: false, userId: nil, error: error)
+                return
             }
-            self.sdkManager.authState.set(accessToken: accessToken)
-            self.sdkManager.authState.set(refreshToken: refreshToken)
-            self.sdkManager.authState.set(userID: userID)
-            self.sdkManager.authState.set(lithiumUserID: lithiumUserID)
-            let currentDate = NSDate()
-            let newDate = NSDate(timeInterval: expiresIn, since: currentDate as Date)
-            self.sdkManager.authState.set(expiryDate: newDate)
-            self.sdkManager.authState.loginSuccessfull()
-            self.loginViewController?.dismiss(animated: true, completion: { self.loginViewController?.delegate = nil })
-            self.authDelegate?.login(status: true, userId: userID, error: nil)
+            self?.sdkManager.authState.loginSuccessfull()
+            self?.loginViewController?.dismiss(animated: true, completion: { self?.loginViewController?.delegate = nil })
+            self?.authDelegate?.login(status: true, userId: self?.sdkManager.authState.userId, error: nil)
             return
-        }) { (error) in
-            self.loginViewController?.dismiss(animated: true, completion: nil)
-            self.authDelegate?.login(status: false, userId: nil, error:error)
+        }) { [weak self](error) in
+            self?.loginViewController?.dismiss(animated: true, completion: nil)
+            self?.authDelegate?.login(status: false, userId: nil, error:error)
         }
     }
 }

--- a/Sources/LiCore/Auth/LiAuthService.swift
+++ b/Sources/LiCore/Auth/LiAuthService.swift
@@ -91,7 +91,7 @@ extension LiAuthService: LiLoginViewControllerProtocol {
      */
     func requestAccessToken(authCode: String) {
         LiRestClient.sharedInstance.request(client: LiClient.getAccessToken(code: authCode), success: { [weak self] (response: LiBaseResponse) in
-            let error = LiAuthResponse().setAuthResponse(data: response.data)
+            let error = AuthResponse().setAuthResponse(data: response.data)
             if error != nil {
                 self?.loginViewController?.dismiss(animated: true, completion: nil)
                 self?.authDelegate?.login(status: false, userId: nil, error: error)

--- a/Sources/LiCore/Auth/LiAuthService.swift
+++ b/Sources/LiCore/Auth/LiAuthService.swift
@@ -91,6 +91,7 @@ extension LiAuthService: LiLoginViewControllerProtocol {
      */
     func requestAccessToken(authCode: String) {
         LiRestClient.sharedInstance.request(client: LiClient.getAccessToken(code: authCode), success: { (response: LiBaseResponse) in
+            //TODO: Move this logic to LiAuthResponse
             guard let accessToken = response.data["access_token"] as? String,
                 let refreshToken = response.data["refresh_token"] as? String,
                 let userID = response.data["userId"] as? String,

--- a/Sources/LiCore/Networking/LiRestClient.swift
+++ b/Sources/LiCore/Networking/LiRestClient.swift
@@ -69,6 +69,7 @@ class LiRestClient {
             } else {
                 oauthHandler.refreshTokens(completion: { succeeded, accessToken, refreshToken, expiresIn, error in
                     if succeeded {
+                        //TODO: Move this logic to LiAuthResponse
                         if let accessToken = accessToken, let refreshToken = refreshToken, let expiresIn = expiresIn {
                             LiSDKManager.shared().authState.set(accessToken: accessToken)
                             LiSDKManager.shared().authState.set(refreshToken: refreshToken)

--- a/Sources/LiCore/Networking/SSOHandler.swift
+++ b/Sources/LiCore/Networking/SSOHandler.swift
@@ -26,6 +26,7 @@ class SSOHandler: RequestRetrier {
     private var requestsToRetry: [RequestRetryCompletion] = []
     func should(_ manager: SessionManager, retry request: Request, with error: Error, completion: @escaping RequestRetryCompletion) {
         let data = request.delegate.data
+        //Do specific check for 401/403. Failure should return 401 according to oauth docs, check with team.
         requestsToRetry.append(completion)
         if !isRefreshing {
             refreshTokens { [weak self] succeeded, accessToken, refreshToken, expiresIn, error in

--- a/Sources/LiCore/Networking/SSOHandler.swift
+++ b/Sources/LiCore/Networking/SSOHandler.swift
@@ -25,7 +25,7 @@ class SSOHandler: RequestRetrier {
     private var requestsToRetry: [RequestRetryCompletion] = []
     func should(_ manager: SessionManager, retry request: Request, with error: Error, completion: @escaping RequestRetryCompletion) {
         lock.lock() ; defer { lock.unlock() }
-        if request.response?.statusCode == 401 {
+        if request.response?.statusCode == LiCoreConstants.ErrorCodes.unauthorized {
             requestsToRetry.append(completion)
             if !isRefreshing {
                 refreshTokens { [weak self] succeeded, error in
@@ -42,7 +42,7 @@ class SSOHandler: RequestRetrier {
                 }
             }
         } else {
-            if request.retryCount == 3 {
+            if request.retryCount == LiCoreConstants.maxRetry {
                 completion(false, 0.0)
                 return
             }

--- a/Sources/LiCore/Utils/LiCoreConstants.swift
+++ b/Sources/LiCore/Utils/LiCoreConstants.swift
@@ -14,6 +14,7 @@
 
 import Foundation
 public struct LiCoreConstants {
+    public static let maxRetry = 3
     public struct ErrorCodes {
         public static let forbidden = 403
         public static let unauthorized = 401


### PR DESCRIPTION
Failed requests were previously checking for 401 inside the 500 error response from API proxy, now since API proxy is bypassed, failed requests will check the response's HTTP code directly.
Also, requests that do not return 401 but fail, will be retired three times before quitting.
AuthResponse is now added to remove the responsibility of saving tokens, for respective calling methods.