### PR TITLE
MOB-503 Refresh token call now gets completed successfully.

### DIFF
--- a/Sources/LiCore/Networking/LiClient.swift
+++ b/Sources/LiCore/Networking/LiClient.swift
@@ -203,13 +203,9 @@ extension LiClient {
     internal var headers: HTTPHeaders {
         let clientID = LiSDKManager.shared().appCredentials.clientId
         let clientAppName = LiSDKManager.shared().appCredentials.clientAppName
-        let accessToken = LiSDKManager.shared().authState.accessToken
         let visitorId = LiSDKManager.shared().visitorId ?? ""
         var headers: [String: String] = ["client-id": clientID, "Visitor-Id": visitorId, "Application-Identifier": clientAppName, "Application-Version": LiQueryConstant.apiVersion, "Content-Type": "application/json" ]
         switch self {
-        case .refreshAccessToken:
-            // In case of only refresh token call returning early without adding `authorization` header.
-            return headers
         case .liGenericPutClient(let requestParams):
             if let additionalHttpHeaders = requestParams.additionalHttpHeaders {
                 headers.update(other: additionalHttpHeaders)
@@ -227,10 +223,6 @@ extension LiClient {
             }
         default:
             break
-        }
-        if LiSDKManager.shared().authManager.isUserLoggedIn() {
-            headers["Authorization"] = "Bearer " + (accessToken ?? "")
-            headers["Auth-Service-Authorization"] = "default"
         }
         return headers
     }

--- a/Sources/LiCore/Networking/LiClient.swift
+++ b/Sources/LiCore/Networking/LiClient.swift
@@ -206,11 +206,10 @@ extension LiClient {
         let accessToken = LiSDKManager.shared().authState.accessToken
         let visitorId = LiSDKManager.shared().visitorId ?? ""
         var headers: [String: String] = ["client-id": clientID, "Visitor-Id": visitorId, "Application-Identifier": clientAppName, "Application-Version": LiQueryConstant.apiVersion, "Content-Type": "application/json" ]
-        if LiSDKManager.shared().authManager.isUserLoggedIn() {
-            headers["Authorization"] = "Bearer " + (accessToken ?? "")
-            headers["Auth-Service-Authorization"] = "default"
-        }
         switch self {
+        case .refreshAccessToken:
+            // In case of only refresh token call returning early without adding `authorization` header.
+            return headers
         case .liGenericPutClient(let requestParams):
             if let additionalHttpHeaders = requestParams.additionalHttpHeaders {
                 headers.update(other: additionalHttpHeaders)
@@ -228,6 +227,10 @@ extension LiClient {
             }
         default:
             break
+        }
+        if LiSDKManager.shared().authManager.isUserLoggedIn() {
+            headers["Authorization"] = "Bearer " + (accessToken ?? "")
+            headers["Auth-Service-Authorization"] = "default"
         }
         return headers
     }

--- a/Sources/LiCore/Networking/LiRestClient.swift
+++ b/Sources/LiCore/Networking/LiRestClient.swift
@@ -50,6 +50,11 @@ class LiRestClient {
                                 return
                             }
                         }
+                        // This is executed when even when the user is logged in and access token is nil.
+                        if let error = response.error as? LiBaseError, error.httpCode == LiCoreConstants.ErrorCodes.emptyAccessTokenError {
+                            failure(error)
+                            return
+                        }
                         do {
                             let data = try LiApiResponse.getLiBaseError(data: response.data)
                             failure(data)

--- a/Sources/LiCore/Networking/LiRestClient.swift
+++ b/Sources/LiCore/Networking/LiRestClient.swift
@@ -24,6 +24,7 @@ class LiRestClient {
     internal let sessionManager = SessionManager()
     private let oauthHandler = SSOHandler()
     init() {
+        sessionManager.adapter = oauthHandler
         sessionManager.retrier = oauthHandler
     }
     func request <T: Router> (client: T, success: @escaping Success, failure: @escaping Failure) {

--- a/Sources/LiCore/Networking/SSOHandler.swift
+++ b/Sources/LiCore/Networking/SSOHandler.swift
@@ -14,7 +14,7 @@
 
 import Foundation
 import Alamofire
-class SSOHandler: RequestRetrier {
+class SSOHandler: RequestAdapter, RequestRetrier {
     private let sessionManager: SessionManager = {
         let configuration = URLSessionConfiguration.default
         configuration.httpAdditionalHeaders = SessionManager.defaultHTTPHeaders
@@ -23,9 +23,21 @@ class SSOHandler: RequestRetrier {
     private let lock = NSLock()
     private var isRefreshing = false
     private var requestsToRetry: [RequestRetryCompletion] = []
+    // MARK: - RequestAdapter
+    func adapt(_ urlRequest: URLRequest) throws -> URLRequest {
+        if LiSDKManager.shared().authManager.isUserLoggedIn() {
+            var urlRequest = urlRequest
+            let accessToken = LiSDKManager.shared().authState.accessToken ?? ""
+            urlRequest.setValue("Bearer " + accessToken, forHTTPHeaderField: "Authorization")
+            urlRequest.setValue("default", forHTTPHeaderField: "Auth-Service-Authorization")
+            return urlRequest
+        }
+        return urlRequest
+    }
+    // MARK: - RequestRetrier
     func should(_ manager: SessionManager, retry request: Request, with error: Error, completion: @escaping RequestRetryCompletion) {
         lock.lock() ; defer { lock.unlock() }
-        if request.response?.statusCode == LiCoreConstants.ErrorCodes.unauthorized {
+        if request.response?.statusCode == LiCoreConstants.ErrorCodes.unauthorized || request.response?.statusCode == LiCoreConstants.ErrorCodes.forbidden {
             requestsToRetry.append(completion)
             if !isRefreshing {
                 refreshTokens { [weak self] succeeded, error in

--- a/Sources/LiCore/Networking/SSOHandler.swift
+++ b/Sources/LiCore/Networking/SSOHandler.swift
@@ -26,11 +26,14 @@ class SSOHandler: RequestAdapter, RequestRetrier {
     // MARK: - RequestAdapter
     func adapt(_ urlRequest: URLRequest) throws -> URLRequest {
         if LiSDKManager.shared().authManager.isUserLoggedIn() {
-            var urlRequest = urlRequest
-            let accessToken = LiSDKManager.shared().authState.accessToken ?? ""
-            urlRequest.setValue("Bearer " + accessToken, forHTTPHeaderField: "Authorization")
-            urlRequest.setValue("default", forHTTPHeaderField: "Auth-Service-Authorization")
-            return urlRequest
+            if let accessToken = LiSDKManager.shared().authState.accessToken {
+                var urlRequest = urlRequest
+                urlRequest.setValue("Bearer " + accessToken, forHTTPHeaderField: "Authorization")
+                urlRequest.setValue("default", forHTTPHeaderField: "Auth-Service-Authorization")
+                return urlRequest
+            } else {
+                throw LiBaseError(errorMessage: LiCoreConstants.ErrorMessages.emptyAccessTokenError, httpCode: LiCoreConstants.ErrorCodes.emptyAccessTokenError)
+            }
         }
         return urlRequest
     }

--- a/Sources/LiCore/Utils/LiCoreConstants.swift
+++ b/Sources/LiCore/Utils/LiCoreConstants.swift
@@ -21,6 +21,7 @@ public struct LiCoreConstants {
         public static let serverError = 500
         public static let serviceUnavailable = 503
         ///Thrown when unknown error json format is recieved.
+        public static let emptyAccessTokenError = 102
         public static let jsonSyntaxError = 104
         public static let noResponseFound = 105
     }
@@ -31,6 +32,7 @@ public struct LiCoreConstants {
         public static let invalidAuthCode = "Response does not contain authCode"
         public static let refreshFailed = "Failed to refresh access token."
         public static let noResponse = "Server returned no response."
+        public static let emptyAccessTokenError = "Invalid Access token, please log out and log in again."
     }
     public struct UserDefaultConstants {
         public static let liAccessToken = "LiAccessToken"


### PR DESCRIPTION
Previously, old access token was being to the header of the refresh token call leading to its failure. Now the refresh token calls do not contain the access token in their header.