### PR TITLE
Basic Auth to load Community URL in webview/login.

### DIFF
--- a/LiCore.podspec
+++ b/LiCore.podspec
@@ -1,13 +1,13 @@
 Pod::Spec.new do |s|
   s.name         = "LiCore"
-  s.version      = "0.4.0"
+  s.version      = "0.5.0"
   s.summary      = "Lithium community Core SDK"
   s.homepage     = "http://community.lithium.com/"
   s.license      = "Apache License, Version 2.0"
   s.author       = { "Shekhar Dahore" => "shekhar.dahore@lithium.com" }
   s.platform     = :ios, "9.0"
   s.swift_version = "5.0"
-  s.source       = { :git => 'https://github.com/lithiumtech/li-ios-sdk.git', :tag => '0.4.0' }
+  s.source       = { :git => 'https://github.com/lithiumtech/li-ios-sdk.git', :tag => '0.5.0' }
   s.source_files = "Sources/LiCore/*", "Sources/LiCore/**/*.{swift,h,m}"
   s.exclude_files = "Sources/LiCore/Info.plist"
   s.resource_bundles = { "LiCore"  => "Sources/LiCore/Resources/*"}

--- a/LiUIComponents.podspec
+++ b/LiUIComponents.podspec
@@ -2,7 +2,7 @@
 Pod::Spec.new do |s|
 
   s.name               = "LiUIComponents"
-  s.version            = "0.4.0"
+  s.version            = "0.5.0"
   s.summary            = "Lithium community iOS SDK UI components."
   s.description        = "LiUIComponents is the UI component of lithium comunity for integrating into partner iOS apps."
   s.homepage           = "https://community.lithium.com"
@@ -10,10 +10,10 @@ Pod::Spec.new do |s|
   s.author             = { "Shekhar Dahore" => "shekhar.dahore@lithium.com" }
   s.platform           = :ios, "11.0"
   s.swift_version      = "5"
-  s.source             = { :git => "https://github.com/lithiumtech/li-ios-sdk.git", :tag => "0.4.0" }
+  s.source             = { :git => "https://github.com/lithiumtech/li-ios-sdk.git", :tag => "0.5.0" }
   s.source_files       = "Sources/LiUIComponents/*", "Sources/LiUIComponents/**/*.{swift,h,m}"
   s.exclude_files      = "Sources/LiUIComponents/Info.plist"
   s.resource_bundles   = { "LiUIComponents" => ["Sources/LiUIComponents/Resources/*", "Sources/LiUIComponents/**/*.{xib,storyboard}", "Sources/LiUIComponents/**/*.xcassets"]}
   s.resources          = ["Sources/LiUIComponents/Resources/*", "Sources/LiUIComponents/**/*.{xib,storyboard}", "Sources/LiUIComponents/**/*.xcassets" ]
-  s.dependency "LiCore", "0.4.0"
+  s.dependency "LiCore", "0.5.0"
 end

--- a/Sources/LiCore/Auth/LiLoginViewController.swift
+++ b/Sources/LiCore/Auth/LiLoginViewController.swift
@@ -64,6 +64,17 @@ class LiLoginViewController: UIViewController, WKNavigationDelegate {
     }
     
     func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction, decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
+        let communityURL: String = LiSDKManager.shared().appCredentials.communityURL
+        if let urlString = navigationAction.request.url?.absoluteString, let htAccessString = KeychainWrapper.standard.string(forKey: "htaccess"), urlString.contains(communityURL) && navigationAction.request.allHTTPHeaderFields?["Authorization"] == nil {
+            let loginData = htAccessString.data(using: String.Encoding.utf8)!
+            let base64LoginString = loginData.base64EncodedString()
+            let newRequest: NSMutableURLRequest = (navigationAction.request as NSURLRequest).mutableCopy() as! NSMutableURLRequest
+            newRequest.addValue("Basic \(base64LoginString)", forHTTPHeaderField: "Authorization")
+            decisionHandler(.cancel)
+            webView.load(newRequest as URLRequest)
+            return
+        }
+        
         let queryParameters = navigationAction.request.url?.liQueryItems ?? [:]
         if queryParameters["response_type"] != nil {
             decisionHandler(.allow)

--- a/Sources/LiCore/Keychain/KeychainItemAccessibility.swift
+++ b/Sources/LiCore/Keychain/KeychainItemAccessibility.swift
@@ -32,7 +32,7 @@ protocol KeychainAttrRepresentable {
 }
 
 // MARK: - KeychainItemAccessibility
-enum KeychainItemAccessibility {
+public enum KeychainItemAccessibility {
     /**
      The data in the keychain item cannot be accessed after a restart until the device has been unlocked once by the user.
      

--- a/Sources/LiCore/Keychain/KeychainWrapper.swift
+++ b/Sources/LiCore/Keychain/KeychainWrapper.swift
@@ -41,13 +41,13 @@ private let SecAttrAccessGroup: String! = kSecAttrAccessGroup as String
 private let SecReturnAttributes: String = kSecReturnAttributes as String
 
 /// KeychainWrapper is a class to help make Keychain access in Swift more straightforward. It is designed to make accessing the Keychain services more like using NSUserDefaults, which is much more familiar to people.
-class KeychainWrapper {
+public class KeychainWrapper {
     
     @available(*, deprecated, message: "KeychainWrapper.defaultKeychainWrapper is deprecated, use KeychainWrapper.standard instead")
      static let defaultKeychainWrapper = KeychainWrapper.standard
     
     /// Default keychain wrapper access
-     static let standard = KeychainWrapper()
+    public static let standard = KeychainWrapper()
     
     /// ServiceName is used for the kSecAttrService property to uniquely identify this keychain accessor. If no service name is specified, KeychainWrapper will default to using the bundleIdentifier.
     private (set)  var serviceName: String
@@ -268,7 +268,7 @@ class KeychainWrapper {
     /// - parameter forKey: The key to save the String under.
     /// - parameter withAccessibility: Optional accessibility to use when setting the keychain item.
     /// - returns: True if the save was successful, false otherwise.
-    @discardableResult  func set(_ value: String, forKey key: String, withAccessibility accessibility: KeychainItemAccessibility? = nil) -> Bool {
+    @discardableResult public func set(_ value: String, forKey key: String, withAccessibility accessibility: KeychainItemAccessibility? = nil) -> Bool {
         if let data = value.data(using: .utf8) {
             return set(data, forKey: key, withAccessibility: accessibility)
         } else {

--- a/Sources/LiCore/Networking/LiClient.swift
+++ b/Sources/LiCore/Networking/LiClient.swift
@@ -221,6 +221,12 @@ extension LiClient {
             if let visitOriginTime = LiSDKManager.shared().authState.visitOriginTime {
                 headers["Visit-Origin-Time"] = visitOriginTime
             }
+        case .getAccessToken:
+            if let htAccessString = KeychainWrapper.standard.string(forKey: "htaccess") {
+                let loginData = htAccessString.data(using: String.Encoding.utf8)!
+                let base64LoginString = loginData.base64EncodedString()
+                headers["Authorization"] = "Basic \(base64LoginString)"
+            }
         default:
             break
         }


### PR DESCRIPTION
When accessing the community login behind vpn, if there's basic authorization, this can be used to login to it.

Usage is 'KeychainWrapper.standard.set("username:password", forKey: "htaccess")'.
Then on calls to the community url that don't have the authorization header added, this change will add it.

Specifically, it's for rocksnropes which the login page isn't reachable via app without vpn.
