### PR TITLE
LSWE-6725: Fix logout

### DIFF
--- a/LiCore.podspec
+++ b/LiCore.podspec
@@ -1,13 +1,13 @@
 Pod::Spec.new do |s|
   s.name         = "LiCore"
-  s.version      = "0.4.0"
+  s.version      = "0.5.0"
   s.summary      = "Lithium community Core SDK"
   s.homepage     = "http://community.lithium.com/"
   s.license      = "Apache License, Version 2.0"
   s.author       = { "Shekhar Dahore" => "shekhar.dahore@lithium.com" }
   s.platform     = :ios, "9.0"
   s.swift_version = "5.0"
-  s.source       = { :git => 'https://github.com/lithiumtech/li-ios-sdk.git', :tag => '0.4.0' }
+  s.source       = { :git => 'https://github.com/lithiumtech/li-ios-sdk.git', :tag => '0.5.0' }
   s.source_files = "Sources/LiCore/*", "Sources/LiCore/**/*.{swift,h,m}"
   s.exclude_files = "Sources/LiCore/Info.plist"
   s.resource_bundles = { "LiCore"  => "Sources/LiCore/Resources/*"}

--- a/LiUIComponents.podspec
+++ b/LiUIComponents.podspec
@@ -2,7 +2,7 @@
 Pod::Spec.new do |s|
 
   s.name               = "LiUIComponents"
-  s.version            = "0.4.0"
+  s.version            = "0.5.0"
   s.summary            = "Lithium community iOS SDK UI components."
   s.description        = "LiUIComponents is the UI component of lithium comunity for integrating into partner iOS apps."
   s.homepage           = "https://community.lithium.com"
@@ -10,10 +10,10 @@ Pod::Spec.new do |s|
   s.author             = { "Shekhar Dahore" => "shekhar.dahore@lithium.com" }
   s.platform           = :ios, "11.0"
   s.swift_version      = "5"
-  s.source             = { :git => "https://github.com/lithiumtech/li-ios-sdk.git", :tag => "0.4.0" }
+  s.source             = { :git => "https://github.com/lithiumtech/li-ios-sdk.git", :tag => "0.5.0" }
   s.source_files       = "Sources/LiUIComponents/*", "Sources/LiUIComponents/**/*.{swift,h,m}"
   s.exclude_files      = "Sources/LiUIComponents/Info.plist"
   s.resource_bundles   = { "LiUIComponents" => ["Sources/LiUIComponents/Resources/*", "Sources/LiUIComponents/**/*.{xib,storyboard}", "Sources/LiUIComponents/**/*.xcassets"]}
   s.resources          = ["Sources/LiUIComponents/Resources/*", "Sources/LiUIComponents/**/*.{xib,storyboard}", "Sources/LiUIComponents/**/*.xcassets" ]
-  s.dependency "LiCore", "0.4.0"
+  s.dependency "LiCore", "0.5.0"
 end

--- a/Sources/LiCore/Auth/LiLoginViewController.swift
+++ b/Sources/LiCore/Auth/LiLoginViewController.swift
@@ -52,7 +52,6 @@ class LiLoginViewController: UIViewController, WKNavigationDelegate {
         let websiteDataTypes = NSSet(array: [WKWebsiteDataTypeCookies])
         let date = Date(timeIntervalSince1970: 0)
         webView.configuration.websiteDataStore.removeData(ofTypes: websiteDataTypes as! Set<String>, modifiedSince: date) { }
-
     }
     fileprivate func setupTitle() {
         title = "Login"

--- a/Sources/LiCore/Auth/LiLoginViewController.swift
+++ b/Sources/LiCore/Auth/LiLoginViewController.swift
@@ -49,6 +49,10 @@ class LiLoginViewController: UIViewController, WKNavigationDelegate {
         webView.trailingAnchor.constraint(equalTo: view.trailingAnchor).isActive = true
         webView.topAnchor.constraint(equalTo: view.topAnchor).isActive = true
         webView.bottomAnchor.constraint(equalTo: view.bottomAnchor).isActive = true
+        let websiteDataTypes = NSSet(array: [WKWebsiteDataTypeCookies])
+        let date = Date(timeIntervalSince1970: 0)
+        webView.configuration.websiteDataStore.removeData(ofTypes: websiteDataTypes as! Set<String>, modifiedSince: date) { }
+
     }
     fileprivate func setupTitle() {
         title = "Login"

--- a/Sources/LiCore/Managers/LiAuthManager.swift
+++ b/Sources/LiCore/Managers/LiAuthManager.swift
@@ -82,9 +82,9 @@ public class LiAuthManager: NSObject, InternalLiLoginDelegate {
         if isUserLoggedIn() {
             let deviceId = sdkManager?.authState.deviceToken ?? ""
             sdkManager?.clientManager.request(client: .signout(deivceId: deviceId), completionHandler: { (result: Result<[LiGenericQueryResponse]>) in
+                self.clearLocalData()
                 switch result {
                 case .success:
-                    self.clearLocalData()
                     completionHandler(nil)
                 case .failure(let error):
                     completionHandler(error)


### PR DESCRIPTION
1. Clear webview cookie when loading login webview. Otherwise, the stored cookies from previous user-data forces auto-login.
2. On logout, clearLocalData even if signout api fails. Some don't have a signout api. Some can't refresh token. We don't want to fail logout since brandmessenger and community logout needs to be sync'd.