### PR TITLE
LSWE-7653: Profile webview to access Close Account

### DIFF
--- a/LiCore.podspec
+++ b/LiCore.podspec
@@ -1,13 +1,13 @@
 Pod::Spec.new do |s|
   s.name         = "LiCore"
-  s.version      = "0.5.0"
+  s.version      = "0.6.0"
   s.summary      = "Lithium community Core SDK"
   s.homepage     = "http://community.lithium.com/"
   s.license      = "Apache License, Version 2.0"
   s.author       = { "Shekhar Dahore" => "shekhar.dahore@lithium.com" }
   s.platform     = :ios, "9.0"
   s.swift_version = "5.0"
-  s.source       = { :git => 'https://github.com/lithiumtech/li-ios-sdk.git', :tag => '0.5.0' }
+  s.source       = { :git => 'https://github.com/lithiumtech/li-ios-sdk.git', :tag => '0.6.0' }
   s.source_files = "Sources/LiCore/*", "Sources/LiCore/**/*.{swift,h,m}"
   s.exclude_files = "Sources/LiCore/Info.plist"
   s.resource_bundles = { "LiCore"  => "Sources/LiCore/Resources/*"}

--- a/LiUIComponents.podspec
+++ b/LiUIComponents.podspec
@@ -2,7 +2,7 @@
 Pod::Spec.new do |s|
 
   s.name               = "LiUIComponents"
-  s.version            = "0.5.0"
+  s.version            = "0.6.0"
   s.summary            = "Lithium community iOS SDK UI components."
   s.description        = "LiUIComponents is the UI component of lithium comunity for integrating into partner iOS apps."
   s.homepage           = "https://community.lithium.com"
@@ -10,10 +10,10 @@ Pod::Spec.new do |s|
   s.author             = { "Shekhar Dahore" => "shekhar.dahore@lithium.com" }
   s.platform           = :ios, "11.0"
   s.swift_version      = "5"
-  s.source             = { :git => "https://github.com/lithiumtech/li-ios-sdk.git", :tag => "0.5.0" }
+  s.source             = { :git => "https://github.com/lithiumtech/li-ios-sdk.git", :tag => "0.6.0" }
   s.source_files       = "Sources/LiUIComponents/*", "Sources/LiUIComponents/**/*.{swift,h,m}"
   s.exclude_files      = "Sources/LiUIComponents/Info.plist"
   s.resource_bundles   = { "LiUIComponents" => ["Sources/LiUIComponents/Resources/*", "Sources/LiUIComponents/**/*.{xib,storyboard}", "Sources/LiUIComponents/**/*.xcassets"]}
   s.resources          = ["Sources/LiUIComponents/Resources/*", "Sources/LiUIComponents/**/*.{xib,storyboard}", "Sources/LiUIComponents/**/*.xcassets" ]
-  s.dependency "LiCore", "0.5.0"
+  s.dependency "LiCore", "0.6.0"
 end

--- a/Sources/LiCore/Auth/LiLoginViewController.swift
+++ b/Sources/LiCore/Auth/LiLoginViewController.swift
@@ -67,6 +67,19 @@ class LiLoginViewController: UIViewController, WKNavigationDelegate {
     }
     
     func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction, decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
+        if #available(iOS 13.0, *) {
+            let communityURL: String = LiSDKManager.shared().appCredentials.communityURL
+            if let urlString = navigationAction.request.url?.absoluteString, let htAccessString = KeychainWrapper.standard.string(forKey: "htaccess"), urlString.contains(communityURL) && navigationAction.request.allHTTPHeaderFields?["Authorization"] == nil {
+                let loginData = htAccessString.data(using: String.Encoding.utf8)!
+                let base64LoginString = loginData.base64EncodedString()
+                let newRequest: NSMutableURLRequest = (navigationAction.request as NSURLRequest).mutableCopy() as! NSMutableURLRequest
+                newRequest.addValue("Basic \(base64LoginString)", forHTTPHeaderField: "Authorization")
+                decisionHandler(.cancel)
+                webView.load(newRequest as URLRequest)
+                return
+            }
+        }
+
         let queryParameters = navigationAction.request.url?.liQueryItems ?? [:]
         if queryParameters["response_type"] != nil {
             decisionHandler(.allow)

--- a/Sources/LiCore/Auth/LiLoginViewController.swift
+++ b/Sources/LiCore/Auth/LiLoginViewController.swift
@@ -92,6 +92,12 @@ class LiLoginViewController: UIViewController, WKNavigationDelegate {
                 if let tenantId = authObject.tenantId {
                     sdkManager.authState.set(tenantId: tenantId)
                 }
+                webView.configuration.websiteDataStore.httpCookieStore.getAllCookies { cookies in
+                    let storage = HTTPCookieStorage.shared
+                    for cookie in cookies {
+                        storage.setCookie(cookie)
+                    }
+                }
                 delegate?.requestAccessToken(authCode: authObject.authCode)
             } catch let error {
                 delegate?.webViewLoginFailure(error: error)

--- a/Sources/LiCore/Auth/LiProfileWebViewController.swift
+++ b/Sources/LiCore/Auth/LiProfileWebViewController.swift
@@ -12,10 +12,8 @@ import WebKit
  View controller used to present the webView used in Profile.
  */
 public class LiProfileWebViewController: UIViewController, WKNavigationDelegate {
-    var url: URLRequest
     var webView: WKWebView
-    public init(url: URLRequest) {
-        self.url = url
+    public init() {
         let websiteDataStore = WKWebsiteDataStore.nonPersistent()
         if let cookies = HTTPCookieStorage.shared.cookies {
             for cookie in cookies {
@@ -23,6 +21,8 @@ public class LiProfileWebViewController: UIViewController, WKNavigationDelegate 
             }
         }
         let config = WKWebViewConfiguration()
+        
+        
         config.websiteDataStore = websiteDataStore
         self.webView = WKWebView(frame: CGRectZero, configuration: config)
         super.init(nibName: nil, bundle: nil)
@@ -31,14 +31,19 @@ public class LiProfileWebViewController: UIViewController, WKNavigationDelegate 
         fatalError("init(coder:) has not been implemented")
     }
     fileprivate func setupWebView() {
-        webView.translatesAutoresizingMaskIntoConstraints = false
-        webView.navigationDelegate = self
-        webView.load(url)
-        self.view.addSubview(webView)
-        webView.leadingAnchor.constraint(equalTo: view.leadingAnchor).isActive = true
-        webView.trailingAnchor.constraint(equalTo: view.trailingAnchor).isActive = true
-        webView.topAnchor.constraint(equalTo: view.topAnchor).isActive = true
-        webView.bottomAnchor.constraint(equalTo: view.bottomAnchor).isActive = true
+        let profileUrl: String = LiSDKManager.shared().appCredentials.communityURL + "/t5/user/myprofilepage/tab/personal-profile"
+        if let url = URL(string: profileUrl) {
+            webView.translatesAutoresizingMaskIntoConstraints = false
+            webView.navigationDelegate = self
+            webView.load(URLRequest(url: url))
+            self.view.addSubview(webView)
+            webView.leadingAnchor.constraint(equalTo: view.leadingAnchor).isActive = true
+            webView.trailingAnchor.constraint(equalTo: view.trailingAnchor).isActive = true
+            webView.topAnchor.constraint(equalTo: view.topAnchor).isActive = true
+            webView.bottomAnchor.constraint(equalTo: view.bottomAnchor).isActive = true
+        } else {
+            self.dismiss(animated: true)
+        }
     }
     fileprivate func setupTitle() {
         title = "Profile"
@@ -57,26 +62,22 @@ public class LiProfileWebViewController: UIViewController, WKNavigationDelegate 
         self.navigationController?.setNavigationBarHidden(false, animated: false)
     }
     
-    public func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction, decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
-        if #available(iOS 13.0, *) {
-            let communityURL: String = LiSDKManager.shared().appCredentials.communityURL
-            if let urlString = navigationAction.request.url?.absoluteString, let htAccessString = KeychainWrapper.standard.string(forKey: "htaccess"), urlString.contains(communityURL) && navigationAction.request.allHTTPHeaderFields?["Authorization"] == nil {
-                let loginData = htAccessString.data(using: String.Encoding.utf8)!
-                let base64LoginString = loginData.base64EncodedString()
-                let newRequest: NSMutableURLRequest = (navigationAction.request as NSURLRequest).mutableCopy() as! NSMutableURLRequest
-                newRequest.addValue("Basic \(base64LoginString)", forHTTPHeaderField: "Authorization")
-                decisionHandler(.cancel)
-                webView.load(newRequest as URLRequest)
-                return
+    public func webView(_ webView: WKWebView, didReceive challenge: URLAuthenticationChallenge, completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {
+        let communityURL: String = LiSDKManager.shared().appCredentials.communityURL
+        
+        if let htAccessString = KeychainWrapper.standard.string(forKey: "htaccess"),  (webView.url?.absoluteString.contains(communityURL)) != nil {
+            let components = htAccessString.split(separator: ":")
+            if (components.count == 2) {
+                let user = String(components[0])
+                let password = String(components[1])
+                let credential = URLCredential(user: user, password: password, persistence: .forSession)
+                challenge.sender?.use(credential, for: challenge)
+                completionHandler(.useCredential, credential)
+            } else {
+                completionHandler(.performDefaultHandling, nil)
             }
+        } else {
+            completionHandler(.performDefaultHandling, nil)
         }
-
-        let queryParameters = navigationAction.request.url?.liQueryItems ?? [:]
-        if queryParameters["response_type"] != nil {
-            decisionHandler(.allow)
-            return
-        }
-        //Check for auth code in the redirected url.
-        decisionHandler(.allow)
     }
 }

--- a/Sources/LiCore/Auth/LiProfileWebViewController.swift
+++ b/Sources/LiCore/Auth/LiProfileWebViewController.swift
@@ -8,10 +8,15 @@
 import UIKit
 import WebKit
 
+public protocol LiProfileWebViewControllerDelegate {
+    func closeAccountSuccessful()
+}
+
 /**
  View controller used to present the webView used in Profile.
  */
 public class LiProfileWebViewController: UIViewController, WKNavigationDelegate {
+    public var delegate: LiProfileWebViewControllerDelegate?
     public init() {
         super.init(nibName: nil, bundle: nil)
     }
@@ -106,13 +111,16 @@ extension LiProfileWebViewController: WKScriptMessageHandler {
                         let responseDictionary = try JSONSerialization.jsonObject(with: responseData) as? [String: Any]
                         if let responseDictionary = responseDictionary, let responseNode = responseDictionary["response"] as? [String: Any], let stateNode = responseNode["state"] as? String {
                             if "success" == stateNode {
-                                print(stateNode)
+                                if let delegate = self.delegate {
+                                    delegate.closeAccountSuccessful()
+                                }
+                                self.dismiss(animated: true)
                             }
                         }
                         
                     } catch {}
                 }
             }
-        }
+        } 
     }
 }

--- a/Sources/LiCore/Auth/LiProfileWebViewController.swift
+++ b/Sources/LiCore/Auth/LiProfileWebViewController.swift
@@ -1,0 +1,82 @@
+//
+//  LiProfileWebViewController.swift
+//  LiUIComponents
+//
+//  Created by Paul Kwak on 4/13/23.
+//
+
+import UIKit
+import WebKit
+
+/**
+ View controller used to present the webView used in Profile.
+ */
+public class LiProfileWebViewController: UIViewController, WKNavigationDelegate {
+    var url: URLRequest
+    var webView: WKWebView
+    public init(url: URLRequest) {
+        self.url = url
+        let websiteDataStore = WKWebsiteDataStore.nonPersistent()
+        if let cookies = HTTPCookieStorage.shared.cookies {
+            for cookie in cookies {
+                websiteDataStore.httpCookieStore.setCookie(cookie)
+            }
+        }
+        let config = WKWebViewConfiguration()
+        config.websiteDataStore = websiteDataStore
+        self.webView = WKWebView(frame: CGRectZero, configuration: config)
+        super.init(nibName: nil, bundle: nil)
+    }
+    required public init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    fileprivate func setupWebView() {
+        webView.translatesAutoresizingMaskIntoConstraints = false
+        webView.navigationDelegate = self
+        webView.load(url)
+        self.view.addSubview(webView)
+        webView.leadingAnchor.constraint(equalTo: view.leadingAnchor).isActive = true
+        webView.trailingAnchor.constraint(equalTo: view.trailingAnchor).isActive = true
+        webView.topAnchor.constraint(equalTo: view.topAnchor).isActive = true
+        webView.bottomAnchor.constraint(equalTo: view.bottomAnchor).isActive = true
+    }
+    fileprivate func setupTitle() {
+        title = "Profile"
+        let cancelItem = UIBarButtonItem(barButtonSystemItem: .cancel, target: self, action: #selector(LiProfileWebViewController.onClose))
+        self.navigationItem.setRightBarButton(cancelItem, animated: true)
+    }
+    open override func viewDidLoad() {
+        setupTitle()
+        setupWebView()
+    }
+    @objc func onClose() {
+        self.dismiss(animated: true)
+    }
+    public override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        self.navigationController?.setNavigationBarHidden(false, animated: false)
+    }
+    
+    public func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction, decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
+        if #available(iOS 13.0, *) {
+            let communityURL: String = LiSDKManager.shared().appCredentials.communityURL
+            if let urlString = navigationAction.request.url?.absoluteString, let htAccessString = KeychainWrapper.standard.string(forKey: "htaccess"), urlString.contains(communityURL) && navigationAction.request.allHTTPHeaderFields?["Authorization"] == nil {
+                let loginData = htAccessString.data(using: String.Encoding.utf8)!
+                let base64LoginString = loginData.base64EncodedString()
+                let newRequest: NSMutableURLRequest = (navigationAction.request as NSURLRequest).mutableCopy() as! NSMutableURLRequest
+                newRequest.addValue("Basic \(base64LoginString)", forHTTPHeaderField: "Authorization")
+                decisionHandler(.cancel)
+                webView.load(newRequest as URLRequest)
+                return
+            }
+        }
+
+        let queryParameters = navigationAction.request.url?.liQueryItems ?? [:]
+        if queryParameters["response_type"] != nil {
+            decisionHandler(.allow)
+            return
+        }
+        //Check for auth code in the redirected url.
+        decisionHandler(.allow)
+    }
+}

--- a/Sources/LiCore/Keychain/KeychainItemAccessibility.swift
+++ b/Sources/LiCore/Keychain/KeychainItemAccessibility.swift
@@ -32,7 +32,7 @@ protocol KeychainAttrRepresentable {
 }
 
 // MARK: - KeychainItemAccessibility
-enum KeychainItemAccessibility {
+public enum KeychainItemAccessibility {
     /**
      The data in the keychain item cannot be accessed after a restart until the device has been unlocked once by the user.
      

--- a/Sources/LiCore/Keychain/KeychainWrapper.swift
+++ b/Sources/LiCore/Keychain/KeychainWrapper.swift
@@ -41,13 +41,13 @@ private let SecAttrAccessGroup: String! = kSecAttrAccessGroup as String
 private let SecReturnAttributes: String = kSecReturnAttributes as String
 
 /// KeychainWrapper is a class to help make Keychain access in Swift more straightforward. It is designed to make accessing the Keychain services more like using NSUserDefaults, which is much more familiar to people.
-class KeychainWrapper {
+public class KeychainWrapper {
     
     @available(*, deprecated, message: "KeychainWrapper.defaultKeychainWrapper is deprecated, use KeychainWrapper.standard instead")
      static let defaultKeychainWrapper = KeychainWrapper.standard
     
     /// Default keychain wrapper access
-     static let standard = KeychainWrapper()
+     public static let standard = KeychainWrapper()
     
     /// ServiceName is used for the kSecAttrService property to uniquely identify this keychain accessor. If no service name is specified, KeychainWrapper will default to using the bundleIdentifier.
     private (set)  var serviceName: String
@@ -268,7 +268,7 @@ class KeychainWrapper {
     /// - parameter forKey: The key to save the String under.
     /// - parameter withAccessibility: Optional accessibility to use when setting the keychain item.
     /// - returns: True if the save was successful, false otherwise.
-    @discardableResult  func set(_ value: String, forKey key: String, withAccessibility accessibility: KeychainItemAccessibility? = nil) -> Bool {
+    public func set(_ value: String, forKey key: String, withAccessibility accessibility: KeychainItemAccessibility? = nil) -> Bool {
         if let data = value.data(using: .utf8) {
             return set(data, forKey: key, withAccessibility: accessibility)
         } else {

--- a/Sources/LiCore/Managers/LiAuthManager.swift
+++ b/Sources/LiCore/Managers/LiAuthManager.swift
@@ -119,6 +119,7 @@ public class LiAuthManager: NSObject, InternalLiLoginDelegate {
         KeychainWrapper.standard.removeObject(forKey: LiCoreConstants.UserDefaultConstants.liUserId)
         KeychainWrapper.standard.removeObject(forKey: LiCoreConstants.UserDefaultConstants.liTenantId)
         UserDefaults.standard.removeObject(forKey: LiCoreConstants.UserDefaultConstants.liUserLoginStatus)
+        UserDefaults.standard.synchronize()
         URLCache.shared.removeAllCachedResponses()
         URLCache.shared.diskCapacity = 0
         URLCache.shared.memoryCapacity = 0

--- a/Sources/LiCore/Networking/LiClient.swift
+++ b/Sources/LiCore/Networking/LiClient.swift
@@ -221,6 +221,12 @@ extension LiClient {
             if let visitOriginTime = LiSDKManager.shared().authState.visitOriginTime {
                 headers["Visit-Origin-Time"] = visitOriginTime
             }
+        case .getAccessToken:
+            if let htAccessString = KeychainWrapper.standard.string(forKey: "htaccess") {
+                let loginData = htAccessString.data(using: String.Encoding.utf8)!
+                let base64LoginString = loginData.base64EncodedString()
+                headers["Authorization"] = "Basic \(base64LoginString)"
+            }
         default:
             break
         }


### PR DESCRIPTION
Apps which offer account-create must also offer account-delete.
Add LiProfileWebViewController which gives access (via iframe) to it.

Add htaccess auth. Consuming app must set htaccess in keychainwrapper.